### PR TITLE
Get-Swagger now exports codecs registered against the ApiInterfaceBase instance

### DIFF
--- a/odinweb/swagger.py
+++ b/odinweb/swagger.py
@@ -125,6 +125,17 @@ class SwaggerSpec(ResourceApi):
         self._ui_cache = None
 
     @lazy_property
+    def cenancestor(self):
+        """
+        Last universal ancestor (or the top level of the API structure).
+        """
+        ancestor = parent = self.parent
+        while parent:
+            ancestor = parent
+            parent = getattr(parent, 'parent', None)
+        return ancestor
+
+    @lazy_property
     def base_path(self):
         """
         Calculate the APIs base path
@@ -212,6 +223,7 @@ class SwaggerSpec(ResourceApi):
         """
         api_base = self.parent
         paths, definitions = self.parse_operations()
+        codecs = getattr(self.cenancestor, 'registered_codecs', CODECS)  # type: dict
         return dict_filter({
             'swagger': '2.0',
             'info': {
@@ -221,8 +233,8 @@ class SwaggerSpec(ResourceApi):
             'host': self.host or request.host,
             'schemes': list(self.schemes) or None,
             'basePath': str(self.base_path),
-            'consumes': list(CODECS.keys()),
-            'produces': list(CODECS.keys()),
+            'consumes': list(codecs.keys()),
+            'produces': list(codecs.keys()),
             'paths': paths,
             'definitions': definitions,
             'securityDefinitions': self.security_definitions(),

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -75,6 +75,22 @@ class TestSwaggerSpec(object):
         assert UrlPath.parse("/api/a/b") == target.base_path
         assert UrlPath.parse("/api/a/b/swagger") == target.swagger_path
 
+    def test_cenancestor(self):
+        target = swagger.SwaggerSpec(title="")
+
+        expected = ApiInterfaceBase(
+            ApiContainer(
+                ApiContainer(
+                    ApiContainer(),
+                    target,
+                    name='b'
+                ),
+                name='a'
+            )
+        )
+
+        assert target.cenancestor is expected
+
     def test_generate_parameters(self):
         actual = swagger.SwaggerSpec.generate_parameters(UrlPath.parse('/api/a/{b}/c/{d:String}'))
         assert actual == [{
@@ -137,11 +153,14 @@ class TestSwaggerSpec(object):
         request = MockRequest()
         target = swagger.SwaggerSpec("Example", schemes='http')
 
-        ApiInterfaceBase(
+        base = ApiInterfaceBase(
             ApiVersion(
                 target,
             ),
         )
+
+        base.registered_codecs.clear()
+        base.registered_codecs['application/yaml'] = None  # Only the keys are used.
 
         actual = target.get_swagger(request)
         expected = {
@@ -153,8 +172,8 @@ class TestSwaggerSpec(object):
             'host': '127.0.0.1',
             'schemes': ['http'],
             'basePath': '/api/v1',
-            'consumes': ['application/json'],
-            'produces': ['application/json'],
+            'consumes': ['application/yaml'],
+            'produces': ['application/yaml'],
             'paths': {},
             'definitions': {
                 'Error': {


### PR DESCRIPTION
Fixes #19 